### PR TITLE
reentrant cJSON parsing and various fixes: allow reliable cJSON stream p...

### DIFF
--- a/include/cJSON.h
+++ b/include/cJSON.h
@@ -81,9 +81,6 @@ extern cJSON *cJSON_GetArrayItem(cJSON *array,int item);
 /* Get item "string" from object. Case insensitive. */
 extern cJSON *cJSON_GetObjectItem(cJSON *object,const char *string);
 
-/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
-extern const char *cJSON_GetErrorPtr();
-
 /* These calls create a cJSON item of the appropriate type. */
 extern cJSON *cJSON_CreateNull();
 extern cJSON *cJSON_CreateTrue();

--- a/src/jsonrpc-c.c
+++ b/src/jsonrpc-c.c
@@ -163,7 +163,7 @@ static void connection_cb(struct ev_loop *loop, ev_io *w, int revents) {
 		return close_connection(loop, w);
 	} else {
 		cJSON *root;
-		char *end_ptr;
+		char *end_ptr = NULL;
 		conn->pos += bytes_read;
 
 		if ((root = cJSON_Parse_Stream(conn->buffer, &end_ptr)) != NULL) {
@@ -187,7 +187,7 @@ static void connection_cb(struct ev_loop *loop, ev_io *w, int revents) {
 		} else {
 			// did we parse the all buffer? If so, just wait for more.
 			// else there was an error before the buffer's end
-			if (cJSON_GetErrorPtr() != (conn->buffer + conn->pos)) {
+			if (end_ptr != (conn->buffer + conn->pos)) {
 				if (server->debug_level) {
 					printf("INVALID JSON Received:\n---\n%s\n---\n",
 							conn->buffer);


### PR DESCRIPTION
...arsing in multiple threads
- instead of setting a global error pointer, the cJSON_Parse_Stream() end_ptr is recursively
  passed down the parser functions and modified.
  (see how strtol() from libc modifies its endptr argument)
- fixed partial parsing of true/false/null constants
- fixed stream parsing in general. the old cJSON "end pointer" was not updated often enough
  to tell between an incomplete and erroneous message reliably.
- fixed space skipping (ignore only actual whitespace characters)
