### PR TITLE
Fix rebuild errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
 AC_INIT([jsonrpc-c], [0.1], [hmng@farol.pt])
 AC_CONFIG_SRCDIR([src/jsonrpc-c.c])
 
+m4_pattern_allow([AM_PROG_AR])
 AM_PROG_AR
 LT_INIT
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])

--- a/example/Makefile.am
+++ b/example/Makefile.am
@@ -19,7 +19,7 @@ noinst_PROGRAMS=server
 server_SOURCES= server.c
 
 # Linker options for a.out
-server_LDFLAGS = $(LIBEV_LIBS) $(top_srcdir)/src/libjsonrpcc.la
+server_LDFLAGS = $(LIBEV_LIBS) $(top_builddir)/src/libjsonrpcc.la
 
 # Compiler options for a.out
 server_CPPFLAGS = $(LIBEV_CFLAGS) -I$(top_srcdir)/include


### PR DESCRIPTION
Hi
 
Coming to build locally I encounter few issues
First I got error due to older autoreconf on our RHEL6.5
Second I needed to compile out of tree.
Both fixes below make this possible.

I also would like to ask if you plan to have some formal releases, and not development tags.
I.E. releases that already includes autoreconf outputs, so users will only do ./configure && make.
This is very common procedure in GNU projects.

Thanks
Noam