### PR TITLE
fix compile warning

### DIFF
--- a/src/jsonrpc-c.c
+++ b/src/jsonrpc-c.c
@@ -32,11 +32,12 @@ static void *get_in_addr(struct sockaddr *sa) {
 }
 
 static int send_response(struct jrpc_connection * conn, char *response) {
+	ssize_t unused;
 	int fd = conn->fd;
 	if (conn->debug_level > 1)
 		printf("JSON Response:\n%s\n", response);
-	write(fd, response, strlen(response));
-	write(fd, "\n", 1);
+	unused = write(fd, response, strlen(response));
+	unused = write(fd, "\n", 1);
 	return 0;
 }
 


### PR DESCRIPTION
There are compile warnings with current version jsonrpc-c. Fix them.

```
jsonrpc-c.c:38:7: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
    write(fd, response, strlen(response));
    ^
jsonrpc-c.c:39:7: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
    write(fd, "\n", 1);
    ^
```
