### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ How?
 It depends on libev (was already used on the embedded app) and includes cJSON (with a small patch on my fork).
 No further dependencies.
 
-###Testing
+### Testing
 
 Run `autoreconf -i`  before `./configure` and `make`
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
